### PR TITLE
Jhakulin/max silence timeout

### DIFF
--- a/samples/async/main.py
+++ b/samples/async/main.py
@@ -76,10 +76,10 @@ class MyAudioCaptureEventHandler(AudioCaptureEventHandler):
             asyncio.run_coroutine_threadsafe(self.client.cancel_response(), self.event_loop)
             self.cancelled = True
 
-            current_item_id = self.event_handler.get_current_conversation_item_id()
-            current_audio_content_index = self.event_handler.get_current_audio_content_id()
-            logger.info(f"Truncate the current audio, current item ID: {current_item_id}, current audio content index: {current_audio_content_index}")
-            asyncio.run_coroutine_threadsafe(self.client.truncate_response(item_id=current_item_id, content_index=current_audio_content_index, audio_end_ms=1000), self.event_loop)
+            #current_item_id = self.event_handler.get_current_conversation_item_id()
+            #current_audio_content_index = self.event_handler.get_current_audio_content_id()
+            #logger.info(f"Truncate the current audio, current item ID: {current_item_id}, current audio content index: {current_audio_content_index}")
+            #asyncio.run_coroutine_threadsafe(self.client.truncate_response(item_id=current_item_id, content_index=current_audio_content_index, audio_end_ms=1000), self.event_loop)
 
             # Restart the audio player
             self.event_handler.audio_player.drain_and_restart()
@@ -295,7 +295,8 @@ async def main():
             tools=functions.definitions,
             tool_choice="auto",
             temperature=0.8,
-            max_output_tokens=None
+            max_output_tokens=None,
+            voice="ballad",
         )
 
         # Define AudioStreamOptions
@@ -336,7 +337,7 @@ async def main():
                 "window_duration": 1.0,
                 "silence_ratio": 1.5,
                 "min_speech_duration": 0.3,
-                "min_silence_duration": 0.3
+                "min_silence_duration": 1.0
             },
             enable_wave_capture=False
         )

--- a/samples/main.py
+++ b/samples/main.py
@@ -67,10 +67,10 @@ class MyAudioCaptureEventHandler(AudioCaptureEventHandler):
             logger.info("Cancelling response.")
             self._client.cancel_response()
 
-            current_item_id = self._event_handler.get_current_conversation_item_id()
-            current_audio_content_index = self._event_handler.get_current_audio_content_id()
-            logger.info(f"Truncate the current audio, current item ID: {current_item_id}, current audio content index: {current_audio_content_index}")
-            self._client.truncate_response(item_id=current_item_id, content_index=current_audio_content_index, audio_end_ms=1000)
+            #current_item_id = self._event_handler.get_current_conversation_item_id()
+            #current_audio_content_index = self._event_handler.get_current_audio_content_id()
+            #logger.info(f"Truncate the current audio, current item ID: {current_item_id}, current audio content index: {current_audio_content_index}")
+            #self._client.truncate_response(item_id=current_item_id, content_index=current_audio_content_index, audio_end_ms=1000)
 
             # Restart the audio player
             self._event_handler.audio_player.drain_and_restart()
@@ -271,7 +271,7 @@ def main():
             tool_choice="auto",
             temperature=0.8,
             max_output_tokens=None,
-            voice="echo",
+            voice="ballad",
         )
 
         # Define AudioStreamOptions
@@ -309,7 +309,7 @@ def main():
                 "window_duration": 1.0,
                 "silence_ratio": 1.5,
                 "min_speech_duration": 0.3,
-                "min_silence_duration": 0.3
+                "min_silence_duration": 1.0
             },
             enable_wave_capture=False
         )

--- a/samples/utils/vad.py
+++ b/samples/utils/vad.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 class VoiceActivityDetector:
     def __init__(self, sample_rate, chunk_size, window_duration=1.0,
-                 silence_ratio=1.5, min_speech_duration=0.3, min_silence_duration=0.3):
+                 silence_ratio=1.5, min_speech_duration=0.3, min_silence_duration=1.0):
         """
         Initialize the Voice Activity Detector (VAD).
 


### PR DESCRIPTION
Increase min_silence_duration to 1.0 sec, this makes the interruption handling more natural as AI do not start speaking if there are short pauses in user's speech

Remove truncating current audio use in interrupts because it is not yet needed and need to understand its usage better,

Changed to new voice 'Ballads' in samples