### PR TITLE
Clear consume event queue in stop

### DIFF
--- a/src/realtime_ai/aio/realtime_ai_client.py
+++ b/src/realtime_ai/aio/realtime_ai_client.py
@@ -54,6 +54,8 @@ class RealtimeAIClient:
                         await self._consume_task
                     except asyncio.CancelledError:
                         logger.info("RealtimeAIClient: consume_events task cancelled.")
+
+                await self.service_manager.clear_event_queue()
             except Exception as e:
                 logger.error(f"RealtimeAIClient: Error during client stop: {e}")
 

--- a/src/realtime_ai/realtime_ai_client.py
+++ b/src/realtime_ai/realtime_ai_client.py
@@ -85,6 +85,7 @@ class RealtimeAIClient:
                     logger.info("RealtimeAIClient: ThreadPoolExecutor shut down.")
                     self.executor = None
 
+                self.service_manager.clear_event_queue()
                 logger.info("RealtimeAIClient: Services stopped.")
             except Exception as e:
                 logger.error(f"RealtimeAIClient: Error during client stop: {e}")


### PR DESCRIPTION
- Fix in realtime client stop to clear the consume event queue.