### PR TITLE
Change asynchronous audio stream manager to use put() instead of put_nowait()

### DIFF
--- a/src/realtime_ai/aio/audio_stream_manager.py
+++ b/src/realtime_ai/aio/audio_stream_manager.py
@@ -39,7 +39,7 @@ class AudioStreamManager:
         if not self.is_streaming:
             self._start_stream()
         logger.info("Enqueuing audio data for streaming.")
-        await self.audio_queue.put_nowait(audio_data)
+        await self.audio_queue.put(audio_data)
         logger.info("Audio data enqueued for streaming.")
 
     async def _stream_audio(self):

--- a/src/realtime_ai/aio/realtime_ai_service_manager.py
+++ b/src/realtime_ai/aio/realtime_ai_service_manager.py
@@ -218,7 +218,7 @@ class RealtimeAIServiceManager:
 
     async def get_next_event(self) -> Optional[EventBase]:
         try:
-            logger.info("RealtimeAIServiceManager: Waiting for next event...")
+            logger.debug("RealtimeAIServiceManager: Waiting for next event...")
             return await asyncio.wait_for(self.event_queue.get(), timeout=5.0)
         except asyncio.TimeoutError:
             return None


### PR DESCRIPTION
As reported in #17. I snuck in a small change to the logging as well since I find my log is overwhelmed with "Waiting for next event..." messages. But I can remove that change and resubmit if you disagree.